### PR TITLE
Update strings.xml

### DIFF
--- a/values-pl/strings.xml
+++ b/values-pl/strings.xml
@@ -188,9 +188,9 @@
     <string name="sort_option_date_created_descending">Data (Malejąco)</string>
     <string name="sort_option_color">Kolor</string>
 
-    <string name="date_ending_st">%sst</string>
-    <string name="date_ending_nd">%snd</string>
-    <string name="date_ending_rd">%srd</string>
-    <string name="date_ending_th">%sth</string>
+    <string name="date_ending_st">%s.</string>
+    <string name="date_ending_nd">%s.</string>
+    <string name="date_ending_rd">%s.</string>
+    <string name="date_ending_th">%s.</string>
 
 </resources>


### PR DESCRIPTION
In Polish there are no endings in dates like st, nd, rd. Spelling 1-szy, 2-gi, 3-ci etc is spelling error and correct form is 1., 2., 3., just numbers ending with dot so it must be ending with dot or left untranslated.
