### PR TITLE
Update strings.xml

### DIFF
--- a/values-vi/strings.xml
+++ b/values-vi/strings.xml
@@ -61,7 +61,7 @@
     <string name="et_hint_confirm_password">Xác nhận mật khẩu</string>
     <string name="et_hint_username">Tên người dùng</string>
     <string name="et_hint_description">Mô tả</string>
-    <string name="et_hint_custom_characters">Nhập ký tự tuỳ chỉnh tại đây</string>
+    <string name="et_hint_custom_characters">Nhập ký tự tuỳ chọn tại đây</string>
     <string name="error_passwords_dont_match">Mật khẩu không trùng khớp</string>
     <string name="error_incorrect_password">Sai mật khẩu</string>
     <string name="error_blank_pass_title">Không thể để trống tiêu đề</string>


### PR DESCRIPTION
- Only one last change in word choice.
- The last four strings of date ending don't seem to affect VNese translation. They still show as English dates (e.g. October 10.). I don't know what's wrong with it because my phone and other apps show VNese dates as 10-10 or Ngày 10 tháng 10.???
